### PR TITLE
Fix problem wit e+06 notation in wig files created by bedtools

### DIFF
--- a/src/DaPars_main.py
+++ b/src/DaPars_main.py
@@ -504,7 +504,7 @@ def Load_Target_Wig_files(All_Wig_files, UTR_Annotation_file):
                     curr_sample_All_chroms_coverage_dict[chrom_name][0].append(region_start)
                     curr_sample_All_chroms_coverage_dict[chrom_name][1].append(0)
                 curr_sample_All_chroms_coverage_dict[chrom_name][0].append(region_end)
-                curr_sample_All_chroms_coverage_dict[chrom_name][1].append(int(fields[-1]))
+                curr_sample_All_chroms_coverage_dict[chrom_name][1].append(int(float(fields[-1])))
             num_line += 1
         curr_sample_All_chroms_coverage_dict[chrom_name][1].append(0)
         All_Samples_Total_depth.append(cur_sample_total_depth)


### PR DESCRIPTION
Fixed Problem with e+06 notation of bedtools in wig files. Fix was already added in line 500 but not in 507!

Without these line I get an error:

[Thu Oct 22 11:07:33 2015] Start Analysis ...
[Thu Oct 22 11:07:33 2015] Loading coverage ...
Traceback (most recent call last):
  File "/home/proj/software/DaPars/DaPars_0.9.1/DaPars_main.py", line 548, in <module>
    De_Novo_3UTR_Identification_Loading_Target_Wig_for_TCGA_Multiple_Samples_Main(sys.argv)
  File "/home/proj/software/DaPars/DaPars_0.9.1/DaPars_main.py", line 154, in De_Novo_3UTR_Identification_Loading_Target_Wig_for_TCGA_Multiple_Samples_Main
    All_samples_Target_3UTR_coverages, All_samples_sequencing_depths, UTR_events_dict = Load_Target_Wig_files(All_Sample_files, Annotated_3UTR_file)
  File "/home/proj/software/DaPars/DaPars_0.9.1/DaPars_main.py", line 507, in Load_Target_Wig_files
    curr_sample_All_chroms_coverage_dict[chrom_name][1].append(int(fields[-1]))
ValueError: invalid literal for int() with base 10: '1.20705e+06'
